### PR TITLE
chore(tracing): allow extract to fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,6 +244,10 @@ class Tracing {
             throw new Error('extract called without a carrier');
         }
 
+        if (!carrier[HttpHeaders.TraceId]) {
+            return null;
+        }
+
         // XXX: no empty string here v
         // We should send the span name too
         // TODO: take a look for span name here: https://github.com/openzipkin/zipkin-go-opentracing/blob/594640b9ef7e5c994e8d9499359d693c032d738c/propagation_ot.go#L26


### PR DESCRIPTION
returning `null` can be used to signal an extraction error, e.g. when no trace
exists in the request. In this case one can properly start a new root span, if
desired, like this:

```javascript
let parent = tracer.extract(ZipkinJavascriptOpentracing.FORMAT_HTTP_HEADERS, headers);
let span;
if (parent) {
  span = tracer.startSpan('myName', { childOf: parent });
} else {
  span = tracer.startSpan('myName');
}
```